### PR TITLE
Corrects tailwind config to use cjs module exports as per Skeleton docs.

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -4,6 +4,5 @@
 	"trailingComma": "none",
 	"printWidth": 100,
 	"plugins": ["prettier-plugin-svelte"],
-	"pluginSearchDirs": ["."],
 	"overrides": [{ "files": "*.svelte", "options": { "parser": "svelte" } }]
 }

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,5 +1,8 @@
 <script>
-	import '../app.postcss';
+	import hljs from 'highlight.js';
+	import 'highlight.js/styles/github-dark.css';
+	import { storeHighlightJs } from '@skeletonlabs/skeleton';
+	storeHighlightJs.set(hljs);
 
 	// Your selected Skeleton theme:
 	import '@skeletonlabs/skeleton/themes/theme-crimson.css';
@@ -9,10 +12,6 @@
 
 	// Finally, your application's global stylesheet (sometimes labeled 'app.css')
 	import '../app.postcss';
-	import hljs from 'highlight.js';
-	import 'highlight.js/styles/github-dark.css';
-	import { storeHighlightJs } from '@skeletonlabs/skeleton';
-	storeHighlightJs.set(hljs);
 </script>
 
 <slot />

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,5 +1,5 @@
 /** @type {import('tailwindcss').Config} */
-export default {
+module.exports = {
 	// 1. Apply the dark mode class setting:
 	darkMode: 'class',
 	content: [


### PR DESCRIPTION
Removes pluginSearchDirs option from Prettier config as it no longer exists in v3. Refactors +layout.svelte imports and removes duplicate app.postcss